### PR TITLE
docs parsing

### DIFF
--- a/cmake/docs-ci.cmake
+++ b/cmake/docs-ci.cmake
@@ -25,9 +25,9 @@ if(index EQUAL "-1")
 endif()
 string(SUBSTRING "${content}" "${index}" -1 content)
 
-string(FIND "${content}" "\n)\n" index)
+string(FIND "${content}" ")\n" index)
 if(index EQUAL "-1")
-  message(FATAL_ERROR "Could not find \"\\n)\\n\"")
+  message(FATAL_ERROR "Could not find \"\)\\n\"")
 endif()
 string(SUBSTRING "${content}" 0 "${index}" content)
 


### PR DESCRIPTION
update docs-ci parsing after cmake-format broke it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the detection of the closing parenthesis in project configuration, enhancing compatibility with different formatting styles in CMake files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->